### PR TITLE
Fix multiple instance issue

### DIFF
--- a/eqsn/gates.py
+++ b/eqsn/gates.py
@@ -61,6 +61,7 @@ class EQSN(object):
             p.join()
         self.shared_dict.stop_shared_dict()
         self.process_picker.stop_process_picker()
+        EQSN.__instance = None
 
     def X_gate(self, q_id):
         """

--- a/eqsn/gates.py
+++ b/eqsn/gates.py
@@ -15,8 +15,18 @@ class EQSN(object):
     All functions are threadsafe, but at the moment, only one instance should be
     used.
     """
+    __instance = None
+
+    @staticmethod
+    def get_instance():
+        if EQSN.__instance is None:
+            return EQSN()
+        return EQSN.__instance
 
     def __init__(self):
+        if EQSN.__instance is not None:
+            raise ValueError("Use get instance to get this class")
+        EQSN.__instance = self
         self.manager = multiprocessing.Manager()
         self.shared_dict = SharedDict.get_instance()
         cpu_count = multiprocessing.cpu_count()

--- a/tests/test_multi_gate.py
+++ b/tests/test_multi_gate.py
@@ -3,7 +3,7 @@ import time
 
 
 def test_epr_creation():
-    q_sim = EQSN()
+    q_sim = EQSN.get_instance()
     id1 = str(1)
     id2 = str(2)
     q_sim.new_qubit(id1)

--- a/tests/test_multiple_instances_eqsn.py
+++ b/tests/test_multiple_instances_eqsn.py
@@ -8,17 +8,22 @@ def test_get_instance():
     i2 = EQSN.get_instance()
     assert i1 == i2
     i1.stop_all()
+    i2.stop_all()
     print("Test succesfull")
 
 
 def test_error_at_creating_EQSN_twice():
+    print("Start error at multiple instances test...")
     error = False
+    i1 = None
     try:
-        _ = EQSN()
+        i1 = EQSN()
         _ = EQSN()
     except:
         error = True
     assert error
+    print("Finished test")
+    i1.stop_all()
 
 
 if __name__ == "__main__":

--- a/tests/test_multiple_instances_eqsn.py
+++ b/tests/test_multiple_instances_eqsn.py
@@ -1,0 +1,27 @@
+from eqsn import EQSN
+import time
+
+
+def test_get_instance():
+    print("test get instance...")
+    i1 = EQSN.get_instance()
+    i2 = EQSN.get_instance()
+    assert i1 == i2
+    i1.stop_all()
+    print("Test succesfull")
+
+
+def test_error_at_creating_EQSN_twice():
+    error = False
+    try:
+        _ = EQSN()
+        _ = EQSN()
+    except:
+        error = True
+    assert error
+
+
+if __name__ == "__main__":
+    test_get_instance()
+    time.sleep(0.1)
+    test_error_at_creating_EQSN_twice()

--- a/tests/test_single_gate.py
+++ b/tests/test_single_gate.py
@@ -3,7 +3,7 @@ from eqsn import EQSN
 import time
 
 def test_x_gate():
-    q_sim = EQSN()
+    q_sim = EQSN.get_instance()
     id = str(10)
     q_sim.new_qubit(id)
     q_sim.X_gate(id)
@@ -14,8 +14,8 @@ def test_x_gate():
 
 
 def test_y_gate():
-    q_sim = EQSN()
-    id = str(10)
+    q_sim = EQSN.get_instance()
+    id = str(11)
     q_sim.new_qubit(id)
     q_sim.Y_gate(id)
     q_sim.Y_gate(id)
@@ -26,7 +26,7 @@ def test_y_gate():
 
 
 def test_z_gate():
-    q_sim = EQSN()
+    q_sim = EQSN.get_instance()
     id = str(10)
     q_sim.new_qubit(id)
     q_sim.Z_gate(id)
@@ -37,7 +37,7 @@ def test_z_gate():
 
 
 def test_H_gate():
-    q_sim = EQSN()
+    q_sim = EQSN.get_instance()
     id = str(10)
     q_sim.new_qubit(id)
     q_sim.H_gate(id)
@@ -48,7 +48,7 @@ def test_H_gate():
 
 
 def test_T_gate():
-    q_sim = EQSN()
+    q_sim = EQSN.get_instance()
     id = str(10)
     q_sim.new_qubit(id)
     q_sim.T_gate(id)
@@ -70,7 +70,7 @@ def test_T_gate():
 
 
 def test_S_gate():
-    q_sim = EQSN()
+    q_sim = EQSN.get_instance()
     id = str(11)
     q_sim.new_qubit(id)
     q_sim.H_gate(id)
@@ -84,7 +84,7 @@ def test_S_gate():
 
 
 def test_K_gate():
-    q_sim = EQSN()
+    q_sim = EQSN.get_instance()
     print("test K gate.")
     id = str(11)
     q_sim.new_qubit(id)
@@ -99,7 +99,7 @@ def test_K_gate():
 
 
 def test_measure():
-    q_sim = EQSN()
+    q_sim = EQSN.get_instance()
     id = str(10)
     q_sim.new_qubit(id)
     res = q_sim.measure(id)
@@ -118,4 +118,4 @@ if __name__ == "__main__":
                 test_measure]
     for func in test_list:
         func()
-        time.sleep(0.05)
+        time.sleep(0.1)


### PR DESCRIPTION
Quick fix of an issue, which was due to multiple instance of EQSN. EQSN is now still threadsafe, but does not support multiple instances anymore. Use get_instance() to get an reference to the same instance and use it the same way as before.